### PR TITLE
add <url> field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,8 @@
 
   <name>Qualys WAS Plugin</name>
   <description>Provides a post-deploy step to run a vulnerability scan using the Qualys Web Application Scanning (WAS) service.</description>
-
+  <url>https://github.com/jenkinsci/qualys-was-plugin</url>
+	
   <licenses>
     <license>
       <name>GNU General Public License v3.0</name>


### PR DESCRIPTION
update pom.xml so that plugin docs points to GitHub
see https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/#how-to-enable-github-documentation-for-your-plugin