### PR TITLE
List can be empty

### DIFF
--- a/src/main/webapp/js/report.js
+++ b/src/main/webapp/js/report.js
@@ -22,9 +22,11 @@ function showVulnsTable(scanResult){
             	"render":  function ( data, type, row ) {
         			var list = data.list;
         			var auth = "No";
-        			list.forEach(function(val){
-        				if(val.WasScanVulnInstance.authenticated == "false") auth = "Yes";
-        			});
+        			if(list != null) {
+        				list.forEach(function(val){
+        					if(val.WasScanVulnInstance.authenticated == "false") auth = "Yes";
+        				});
+        			}
             		return auth;
     			}
             }


### PR DESCRIPTION
The vulnerabilities tab did not want to display any vulnerabilities.
Found that one of the vulnerabilities returned did not contain .WasScanVuln.instances.list and was the reason for the UI failing to display vulnerabilties.

```
cat bad.json| jq '.vulnsTable.list[] | select(.WasScanVuln.instances.list == null)'
{
  "WasScanVuln": {
    "qid": 38173,
    "title": "SSL Certificate - Signature Verification Failed Vulnerability",
    "instances": {
      "count": 0
    },
    "sslData": {
      "ip": "<redacted>",
      "flags": "v",
      "port": "<redacted>",
      "sslDataInfoList": {
        "list": [
          {
            "SSLDataInfo": {
              "sslDataPropList": {},
              "sslDataKexList": {},
              "sslDataCipherList": {},
              "certificateFingerprint": "<redacted>"
            }
          }
        ]
      },
      "protocol": "tcp",
      "result": "<redacted>",
      "virtualhost": "<redacted>"
    },
    "potential": "true",
    "severity": "2",
    "uri": "https://<redacted>"
  }
}
```